### PR TITLE
優先順位機能追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+/target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,40 @@
-# Compiled class file
-*.class
-
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
+target/
 *.jar
 *.war
-*.nar
 *.ear
-*.zip
-*.tar.gz
-*.rar
+*.class
+.mvn/
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+# macOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE関連
+.idea/
+*.iml
+*.ipr
+*.iws
+.vscode/
+.settings/
+.project
+.classpath
+
+# ログファイル
+*.log
+logs/
+
+# 一時ファイル
+*.tmp
+*.temp
+*~
+
+# OS関連
+*.swp
+*.swo
+
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,4 @@ logs/
 *.swp
 *.swo
 
-hs_err_pid*
-replay_pid*
-/target/
 docker-compose.yml

--- a/src/main/java/com/lesson/memo/controller/MemoController.java
+++ b/src/main/java/com/lesson/memo/controller/MemoController.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,10 +19,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.lesson.memo.model.Memo;
+import com.lesson.memo.model.Priority;
 import com.lesson.memo.repository.MemoRepository;
-
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 
 @Controller
 @RequestMapping("/memo")
@@ -31,6 +32,21 @@ public class MemoController {
     @GetMapping
     public String list(Model model) {
         List<Memo> memos = memoRepository.findAll();
+        // 優先度順（HIGH→MEDIUM→LOW）＋作成日降順でソート
+        memos.sort((a, b) -> {
+            int pa = switch (a.getPriority()) {
+                case HIGH -> 0;
+                case MEDIUM -> 1;
+                case LOW -> 2;
+            };
+            int pb = switch (b.getPriority()) {
+                case HIGH -> 0;
+                case MEDIUM -> 1;
+                case LOW -> 2;
+            };
+            if (pa != pb) return Integer.compare(pa, pb);
+            return b.getCreatedAt().compareTo(a.getCreatedAt());
+        });
         model.addAttribute("memos", memos);
         return "memo-list";
     }
@@ -38,6 +54,7 @@ public class MemoController {
     @GetMapping("/new")
     public String showForm(Model model) {
         model.addAttribute("memo", new Memo());
+        model.addAttribute("priorities", Priority.values()); // ★追加
         return "memo-form";
     }
 
@@ -64,18 +81,22 @@ public class MemoController {
         }
 
         model.addAttribute("memo", memo.get());
+        model.addAttribute("priorities", Priority.values()); // ★追加
+        
         return "memo-detail";
     }
 
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable Long id, Model model, HttpServletResponse response) {
         if (model.containsAttribute("memo")) {
+            model.addAttribute("priorities", Priority.values()); // ★追加
             return "memo-form";
         }
 
         return memoRepository.findById(id)
                 .map(memo -> {
                     model.addAttribute("memo", memo);
+                    model.addAttribute("priorities", Priority.values()); // ★追加
                     return "memo-form";
                 })
                 .orElseGet(() -> {
@@ -107,11 +128,13 @@ public class MemoController {
 
         memoToUpdate.setTitle(memo.getTitle());
         memoToUpdate.setContent(memo.getContent());
+        memoToUpdate.setPriority(memo.getPriority()); // ★追加
         memoToUpdate.setUpdatedAt(LocalDateTime.now());
         memoRepository.save(memoToUpdate);
 
         return "redirect:/memo/detail/" + id;
     }
+
 
     @GetMapping("/delete/{id}")
     public String delete(@PathVariable Long id,

--- a/src/main/java/com/lesson/memo/model/Memo.java
+++ b/src/main/java/com/lesson/memo/model/Memo.java
@@ -2,14 +2,18 @@ package com.lesson.memo.model;
 
 import java.time.LocalDateTime;
 
-import org.springframework.format.annotation.DateTimeFormat;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import lombok.Data;
 
 @Entity
@@ -33,4 +37,8 @@ public class Memo {
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
+    
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Priority priority;
 }

--- a/src/main/java/com/lesson/memo/model/Priority.java
+++ b/src/main/java/com/lesson/memo/model/Priority.java
@@ -1,0 +1,18 @@
+package com.lesson.memo.model;
+
+public enum Priority {
+    HIGH("高", "high"),
+    MEDIUM("中", "medium"),
+    LOW("低", "low");
+
+    private final String label;
+    private final String cssClass;
+
+    Priority(String label, String cssClass) {
+        this.label = label;
+        this.cssClass = cssClass;
+    }
+
+    public String getLabel() { return label; }
+    public String getCssClass() { return cssClass; }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -461,3 +461,74 @@ textarea {
 .note-card-footer.detail-footer .note-actions {
   margin-left: auto;
 }
+
+/* 優先順位：一覧・詳細の表示用 */
+.note-badge {
+  display:inline-block;
+  padding:.25rem .6rem;
+  border-radius:999px;
+  font-weight:700;
+  font-size:.85rem;
+  line-height:1;
+}
+
+.note-badge.high   { background:#dc3545; color:#fff; }
+.note-badge.medium { background:#ffc107; color:#212529; }
+.note-badge.low    { background:#198754; color:#fff; }
+
+/* ラジオグループ全体 */
+.priority-group {
+  display: flex;
+  gap: 1rem;
+}
+
+/* デフォのラジオボタンを非表示 */
+.priority-radio {
+  display: none;
+}
+
+/* pill の共通スタイル */
+/* pill の共通スタイル */
+.priority-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.priority-radio {
+  display: none; /* ラジオ自体は非表示 */
+}
+
+.priority-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: .4rem 1rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: .9rem;
+  cursor: pointer;
+  user-select: none;
+  border: 2px solid transparent;
+  transition: border-color .2s ease, background-color .2s ease;
+}
+
+/* デフォは薄めの色 */
+.priority-pill.high   { background:#f8d7da; color:#721c24; }
+.priority-pill.medium { background:#fff3cd; color:#856404; }
+.priority-pill.low    { background:#d4edda; color:#155724; }
+
+/* ✅ 選択中 */
+.priority-pill:has(.priority-radio:checked) {
+  border-color: #000;
+}
+
+.priority-pill.high:has(.priority-radio:checked) {
+  background:#dc3545; color:#fff;
+}
+.priority-pill.medium:has(.priority-radio:checked) {
+  background:#ffc107; color:#212529;
+}
+.priority-pill.low:has(.priority-radio:checked) {
+  background:#198754; color:#fff;
+}
+

--- a/src/main/resources/templates/memo-detail.html
+++ b/src/main/resources/templates/memo-detail.html
@@ -18,6 +18,10 @@
         <div class="note-card note-card-large">
             <div class="note-card-header">
                 <h2 class="note-card-title" th:text="${memo.title}">タイトル</h2>
+				<span class="note-badge"
+				      th:classappend="${' ' + memo.priority.cssClass}"
+				      th:text="${memo.priority.label}"></span>
+
             </div>
             <div class="note-card-content">
                 <p class="note-card-text" th:text="${memo.content}">本文</p>

--- a/src/main/resources/templates/memo-form.html
+++ b/src/main/resources/templates/memo-form.html
@@ -24,6 +24,22 @@
                     <input type="text" th:field="*{title}">
                     <div th:if="${#fields.hasErrors('title')}" th:errors="*{title}" class="error-message"></div>
                 </div>
+				
+				<div class="form-group">
+				  <label>優先度</label>
+				  <div class="priority-group">
+				    <th:block th:each="p : ${priorities}">
+				      <label class="priority-pill"
+				             th:classappend="${' ' + p.cssClass}">
+				        <input type="radio"
+				               class="priority-radio"
+				               th:field="*{priority}"
+				               th:value="${p}">
+				        <span th:text="${p.label}">中</span>
+				      </label>
+				    </th:block>
+				  </div>
+				</div>
 
                 <div class="form-group">
                     <label>内容：</label>

--- a/src/main/resources/templates/memo-list.html
+++ b/src/main/resources/templates/memo-list.html
@@ -19,23 +19,24 @@
         </div>
 
         <div class="notes-grid">
-            <div class="note-card" th:each="memo : ${memos}">
-                <div class="note-card-header">
-                    <h3 class="note-card-title" th:text="${memo.title}">タイトル</h3>
-                </div>
-                <div class="note-card-content">
-                    <p class="note-card-text" th:text="${memo.content}">内容</p>
-                </div>
-                <div class="note-card-footer">
-                    <p class="note-date" th:text="${#temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm')}">日付</p>
-                    <div class="note-actions">
-                        <a th:href="@{|/memo/detail/${memo.id}|}" class="btn btn-primary">詳細</a>
-                        <a th:href="@{|/memo/delete/${memo.id}|}" class="btn btn-danger">
-                            削除
-                        </a>
-                    </div>
-                </div>
-            </div>
+			<div class="note-card" th:each="memo : ${memos}">
+			    <div class="note-card-header">
+			        <h3 class="note-card-title" th:text="${memo.title}">タイトル</h3>
+					<span class="note-badge"
+					      th:classappend="${' ' + memo.priority.cssClass}"
+					      th:text="${memo.priority.label}"></span>
+			    </div>
+			    <div class="note-card-content">
+			        <p class="note-card-text" th:text="${memo.content}">内容</p>
+			    </div>
+			    <div class="note-card-footer">
+			        <p class="note-date" th:text="${#temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm')}">日付</p>
+			        <div class="note-actions">
+			            <a th:href="@{|/memo/detail/${memo.id}|}" class="btn btn-primary">詳細</a>
+			            <a th:href="@{|/memo/delete/${memo.id}|}" class="btn btn-danger">削除</a>
+			        </div>
+			    </div>
+			</div>
         </div>
 
         <div th:if="${memos.isEmpty()}" class="empty-state">

--- a/src/main/resources/templates/memo-list.html
+++ b/src/main/resources/templates/memo-list.html
@@ -19,24 +19,24 @@
         </div>
 
         <div class="notes-grid">
-			<div class="note-card" th:each="memo : ${memos}">
-			    <div class="note-card-header">
-			        <h3 class="note-card-title" th:text="${memo.title}">タイトル</h3>
-					<span class="note-badge"
-					      th:classappend="${' ' + memo.priority.cssClass}"
-					      th:text="${memo.priority.label}"></span>
-			    </div>
-			    <div class="note-card-content">
-			        <p class="note-card-text" th:text="${memo.content}">内容</p>
-			    </div>
-			    <div class="note-card-footer">
-			        <p class="note-date" th:text="${#temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm')}">日付</p>
-			        <div class="note-actions">
-			            <a th:href="@{|/memo/detail/${memo.id}|}" class="btn btn-primary">詳細</a>
-			            <a th:href="@{|/memo/delete/${memo.id}|}" class="btn btn-danger">削除</a>
-			        </div>
-			    </div>
-			</div>
+            <div class="note-card" th:each="memo : ${memos}">
+                <div class="note-card-header">
+                    <h3 class="note-card-title" th:text="${memo.title}">タイトル</h3>
+                    <span class="note-badge"
+                        th:classappend="${' ' + memo.priority.cssClass}"
+                        th:text="${memo.priority.label}"></span>
+                </div>
+                <div class="note-card-content">
+                    <p class="note-card-text" th:text="${memo.content}">内容</p>
+                </div>
+                <div class="note-card-footer">
+                    <p class="note-date" th:text="${#temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm')}">日付</p>
+                    <div class="note-actions">
+                        <a th:href="@{|/memo/detail/${memo.id}|}" class="btn btn-primary">詳細</a>
+                        <a th:href="@{|/memo/delete/${memo.id}|}" class="btn btn-danger">削除</a>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div th:if="${memos.isEmpty()}" class="empty-state">

--- a/src/main/resources/templates/memo-list.html
+++ b/src/main/resources/templates/memo-list.html
@@ -33,7 +33,9 @@
                     <p class="note-date" th:text="${#temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm')}">日付</p>
                     <div class="note-actions">
                         <a th:href="@{|/memo/detail/${memo.id}|}" class="btn btn-primary">詳細</a>
-                        <a th:href="@{|/memo/delete/${memo.id}|}" class="btn btn-danger">削除</a>
+                        <a th:href="@{|/memo/delete/${memo.id}|}" class="btn btn-danger">
+                            削除
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 概要
メモに「優先度（高・中・低）」を設定できる機能を追加しました。

## 主な変更点
- `Priority` enum を新規追加（高/中/低）
- `Memo` エンティティに `priority` フィールドを追加
- 新規作成・編集フォームに優先度選択用のボタンUIを追加
- 一覧・詳細画面に優先度バッジを表示
- 優先度 → 作成日時の順でソートする処理を追加

## 確認方法
1. メモの新規作成画面で「高・中・低」を選択して保存
2. 編集画面で優先度を変更して保存
3. 一覧・詳細画面で選択した優先度がバッジ表示されることを確認
4. 一覧は「高 → 中 → 低」の順で並び替えられていることを確認
